### PR TITLE
Fix empty data in transforms

### DIFF
--- a/myria3d/pctl/datamodule/hdf5.py
+++ b/myria3d/pctl/datamodule/hdf5.py
@@ -82,21 +82,21 @@ class HDF5LidarDataModule(LightningDataModule):
         )
 
     @property
-    def train_transform(self) -> Compose:
-        return Compose(
+    def train_transform(self) -> CustomCompose:
+        return CustomCompose(
             self.preparation_train_transform
             + self.normalization_transform
             + self.augmentation_transform
         )
 
     @property
-    def eval_transform(self) -> Compose:
-        return Compose(
+    def eval_transform(self) -> CustomCompose:
+        return CustomCompose(
             self.preparation_eval_transform + self.normalization_transform
         )
 
     @property
-    def predict_transform(self) -> Compose:
+    def predict_transform(self) -> CustomCompose:
         return CustomCompose(
             self.preparation_predict_transform + self.normalization_transform
         )

--- a/myria3d/pctl/datamodule/hdf5.py
+++ b/myria3d/pctl/datamodule/hdf5.py
@@ -8,6 +8,7 @@ from torch_geometric.data import Data
 from torch_geometric.transforms import Compose
 
 from myria3d.pctl.dataloader.dataloader import GeometricNoneProofDataloader
+from myria3d.pctl.transforms.compose import CustomCompose
 from myria3d.pctl.dataset.hdf5 import HDF5Dataset
 from myria3d.pctl.dataset.iterable import InferenceDataset
 from myria3d.pctl.dataset.utils import (
@@ -96,7 +97,7 @@ class HDF5LidarDataModule(LightningDataModule):
 
     @property
     def predict_transform(self) -> Compose:
-        return Compose(
+        return CustomCompose(
             self.preparation_predict_transform + self.normalization_transform
         )
 

--- a/myria3d/pctl/dataset/iterable.py
+++ b/myria3d/pctl/dataset/iterable.py
@@ -65,6 +65,9 @@ class InferenceDataset(IterableDataset):
             if self.transform:
                 sample_data = self.transform(sample_data)
 
+            if sample_data is None:
+                continue
+
             if self.pre_filter and self.pre_filter(sample_data):
                 # e.g. not enough points in this receptive field.
                 continue

--- a/myria3d/pctl/transforms/compose.py
+++ b/myria3d/pctl/transforms/compose.py
@@ -18,11 +18,11 @@ class CustomCompose(BaseTransform):
         for transform in self.transforms:
             if isinstance(data, (list, tuple)):
                 data = [transform(d) for d in data]
-                data = [d for d in data if d is not None]
+                data = [d for d in data if d is not None and d.num_nodes != 0]
                 if len(data) == 0:
                     return None
             else:
                 data = transform(data)
-                if data is None:
+                if data is None or data.num_nodes == 0:
                     return None
         return data


### PR DESCRIPTION
- Use CustomCompose to return None, when  a transform lead to empty tensor
- When getting rid of Artefacts point (class 65)
